### PR TITLE
Adds Makefile with install target for creating 'pulley' symlink to pulley.js

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,15 @@
+
+INSTALL_PREFIX="/usr/local/bin"
+
+
+all: clean install
+
+clean:
+	@@rm -rf ${INSTALL_PREFIX}/pulley
+
+install: clean
+	@@ln -s ${PWD}/pulley.js ${INSTALL_PREFIX}/pulley
+	@@echo "Installation complete"
+
+.PHONY: install clean
+


### PR DESCRIPTION
Adds Makefile with install target for creating 'pulley' symlink to pulley.js; allows pulley to be called as:

`node pulley #pid` 

from any project/repo directory
