### PR TITLE
Fix for Issue #9 - Repos w/ hyphens in name

### DIFF
--- a/pulley.js
+++ b/pulley.js
@@ -1,4 +1,4 @@
-:!/usr/bin/env node
+#!/usr/bin/env node
 /*
  * Pulley: Easy Github Pull Request Lander
  * Copyright 2011 John Resig


### PR DESCRIPTION
Found an issue with repos who's names contain hyphens, so I tweaked the regexp to account for this.
