### PR TITLE
Let GitHub close the pull request for us

### DIFF
--- a/pulley.js
+++ b/pulley.js
@@ -186,9 +186,11 @@ function commit( pull ) {
 			return "#" + num;
 		}).join(", ") || "#????") + ".";
 
-		msg += "\n\nMore Details:" + urls.map(function( url ) {
-			return "\n - " + url;
-		}).join("");
+		if ( urls.length ) {
+			msg += "\n\nMore Details:" + urls.map(function( url ) {
+				return "\n - " + url;
+			}).join("");
+		}
 
 		var commit = [ "commit", "-a", "--message=" + msg ];
 
@@ -212,6 +214,7 @@ function commit( pull ) {
 					} else {
 						exec( "git push " + config.remote + " master", function( error, stdout, stderr ) {
 							process.stdout.write( "done.\n" );
+							exit();
 						});
 					}
 				});


### PR DESCRIPTION
By using `closes #xxx` in the commit message GitHub will automatically reference the commit in the pull request and then close it.

[More info](http://stackoverflow.com/a/6742691/64949)

@mikesherov Haven't tested the changes. Any suggestion how I would do that? Maybe have a `test` branch on this repo where you can test changes.
