### PR TITLE
Exit if error is returned when fetching a token

### DIFF
--- a/pulley.js
+++ b/pulley.js
@@ -68,6 +68,10 @@
 					note_url: "https://github.com/jeresig/pulley"
 				}
 			}, function( err, res, body ) {
+				if ( err ) {
+					exit( err );
+				}
+				
 				token = body.token;
 				if ( token ) {
 					exec( "git config --global --add pulley.token " + token, function( error, stdout, stderr ) {


### PR DESCRIPTION
Currently throws `TypeError: Cannot read property of 'token' of undefined` if any issues are encountered fetching the auth token. This prints the error message and exits back to the shell when an error is encountered.
