### PR TITLE
Allow for periods in repo names. e.g. Ember.js, Video.js, Angular.js

### DIFF
--- a/pulley.js
+++ b/pulley.js
@@ -75,7 +75,7 @@
 				if ( err ) {
 					exit( err );
 				}
-				
+
 				token = body.token;
 				if ( token ) {
 					exec( "git config --global --add pulley.token " + token, function( error, stdout, stderr ) {
@@ -95,7 +95,7 @@
 			exit("No pull request ID specified, please provide one.");
 		}
 		exec( "git remote -v show " + config.remote, function( error, stdout, stderr ) {
-			user_repo = ( /URL:.*?([\w\-]+\/[\w\-]+)/.exec( stdout ) || [] )[ 1 ];
+			user_repo = ( /URL:.*?([\w\-]+\/[\w\-\.]+)\.git/.exec( stdout ) || [] )[ 1 ];
 			tracker = config.repos[ user_repo ];
 
 			if ( user_repo ) {


### PR DESCRIPTION
The original regex doesn't support repos with periods in the name.

This assumes .git will end urls, which is true for all github options that I can find.
