### PR TITLE
Let pulley install on multiple computers

### DIFF
--- a/pulley.js
+++ b/pulley.js
@@ -68,7 +68,7 @@
 				},
 				body: {
 					scopes: ["repo"],
-					note: "Pulley",
+					note: "Pulley-" + Date.now(),
 					note_url: "https://github.com/jeresig/pulley"
 				}
 			}, function( err, res, body ) {

--- a/pulley.js
+++ b/pulley.js
@@ -10,6 +10,7 @@
 	var child = require("child_process"),
 		http = require("https"),
 		fs = require("fs"),
+		os = require("os"),
 		prompt = require("prompt"),
 		request = require("request"),
 		colors = require("colors"),
@@ -68,7 +69,7 @@
 				},
 				body: {
 					scopes: ["repo"],
-					note: "Pulley-" + Date.now(),
+					note: "Pulley-" + os.hostname(),
 					note_url: "https://github.com/jeresig/pulley"
 				}
 			}, function( err, res, body ) {


### PR DESCRIPTION
Add a unique suffix to the github api "note" so that pulley can be registered from multiple computers.

Fixes #67
